### PR TITLE
fix(fennel): separate out and man packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning][2].
 
 ## Unreleased
 
+### Improved
+
+- fennel: separate `out` and `man` pacakges.
+  - No need to download pandoc package everytime, useful for CI.
+
 ## [0.2.0] (2024-02-27)
 
 ### Added packages

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ It could look like:
           pkgs.mkShell {
             buildInputs = [
               fennel
+              fennel.man # if you want to read man pages
               pkgs.faith
               pkgs.fnlfmt
               pkgs.fenneldoc

--- a/nix/pkgs/fennel/default.nix
+++ b/nix/pkgs/fennel/default.nix
@@ -8,48 +8,82 @@
 , pandoc
 }:
 
-stdenv.mkDerivation rec {
-  pname = "fennel";
-  inherit version src;
+let
+  out = stdenv.mkDerivation rec {
+    pname = "fennel";
+    inherit version src;
 
-  nativeBuildInputs = [
-    lua
-    pandoc
-  ];
-
-  patches = with lib;
-    optionals (versionOlder version "1.4.2") [
-      (fetchpatch {
-        name = "fix Makefile manpage installation";
-        url = "https://git.sr.ht/~technomancy/fennel/commit/f0e341239b0bdbbc1aa5f2b715a3389e2ab07646.patch";
-        hash = "sha256-/zWcpyb5qd8ffW0FSJsXXm0nq4xWWfdrDpI41+JZZ0E=";
-      })
+    nativeBuildInputs = [
+      lua
     ];
 
-  postPatch = with lib;
-    let
-      version' = strings.escapeRegex version;
-    in
-    optionalString (shortRev != null) ''
-      # Append short commit hash to version string.
-      sed -E -i src/fennel/utils.fnl \
-          -e "s|(local version :)(${version'})(\))|\1${version}-${shortRev}\3|"
+    patches = [
+      ./patches/man-inst.patch
+    ];
+
+    postPatch = with lib;
+      let
+        version' = strings.escapeRegex version;
+      in
+      optionalString (shortRev != null) ''
+        # Append short commit hash to version string.
+        sed -E -i src/fennel/utils.fnl \
+            -e "s|(local version :)(${version'})(\))|\1${version}-${shortRev}\3|"
+      '';
+
+    makeFlags = [
+      "PREFIX=$(out)"
+    ];
+
+    postBuild = ''
+      patchShebangs .
     '';
 
-  makeFlags = [
-    "PREFIX=$(out)"
-  ];
+    passthru = { inherit lua man; };
 
-  postBuild = ''
-    patchShebangs .
-  '';
-
-  passthru = { inherit lua; };
-
-  meta = with lib; {
-    description = "Lua Lisp Language";
-    homepage = "https://fennel-lang.org/";
-    license = licenses.mit;
-    mainProgram = pname;
+    meta = with lib; {
+      description = "Lua Lisp Language";
+      homepage = "https://fennel-lang.org/";
+      license = licenses.mit;
+      mainProgram = pname;
+    };
   };
-}
+
+  man = stdenv.mkDerivation rec {
+    inherit (out) pname version src;
+
+    nativeBuildInputs = [
+      out
+      lua
+      pandoc
+    ];
+
+    patches = with lib;
+      out.patches ++
+      optionals (versionOlder version "1.4.2") [
+        (fetchpatch {
+          name = "fix Makefile manpage installation";
+          url = "https://git.sr.ht/~technomancy/fennel/commit/f0e341239b0bdbbc1aa5f2b715a3389e2ab07646.patch";
+          hash = "sha256-/zWcpyb5qd8ffW0FSJsXXm0nq4xWWfdrDpI41+JZZ0E=";
+        })
+      ];
+
+    postPatch = ''
+      sed -E -i Makefile -e 's|\./fennel|fennel|'
+    '';
+
+    makeFlags = [
+      "PREFIX=$(out)"
+    ];
+
+    buildFlags = [
+      "man"
+    ];
+
+    installTargets = "install-man";
+
+    inherit (out) meta;
+  };
+in
+
+out

--- a/nix/pkgs/fennel/patches/man-inst.patch
+++ b/nix/pkgs/fennel/patches/man-inst.patch
@@ -1,0 +1,20 @@
+commit 025cb6f429564e40de077127c7066f782549b0e8
+Author: NACAMURA Mitsuhiro <m15@m15a.dev>
+Date:   Tue Mar 19 10:59:41 2024 +0900
+
+    fix: separate manpage installation
+
+diff --git a/Makefile b/Makefile
+index e8e570a..210a385 100644
+--- a/Makefile
++++ b/Makefile
+@@ -155,6 +155,9 @@ endef
+ install: fennel fennel.lua
+ 	mkdir -p $(DESTDIR)$(BIN_DIR) && cp fennel $(DESTDIR)$(BIN_DIR)/
+ 	mkdir -p $(DESTDIR)$(LUA_LIB_DIR) && cp fennel.lua $(DESTDIR)$(LUA_LIB_DIR)/
++
++.PHONY: install-man
++install-man: $(MAN_DOCS)
+ 	$(foreach doc,$(MAN_DOCS),\
+ 		$(call maninst,$(doc),$(DESTDIR)$(MAN_DIR)/$(doc)))
+ 


### PR DESCRIPTION
This is to remove dependency to Pandoc, which is useful only for humans.

Close #12 